### PR TITLE
Add usernames under avatars

### DIFF
--- a/templates/topic.tpl
+++ b/templates/topic.tpl
@@ -42,7 +42,8 @@
 								<div class="topic-profile-pic hidden-xs text-center">
 									<a href="<!-- IF posts.user.userslug -->{relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
 										<img src="{posts.user.picture}" alt="{posts.user.username}" class="profile-image user-img" title="{posts.user.username}">
-									</a>
+									</a><br/>
+									<small class="username">{posts.user.username}</small>
 
 									<!-- IF posts.user.groups.length -->
 									<div class="text-center">


### PR DESCRIPTION
As discussed in [this](https://community.nodebb.org/topic/2019/changing-template-file-with-a-plugin) topic, usernames should ideally be on the left, I have purposefully left the username class empty, so either we can come up with a solution to long usernames, or people can decide how they want it to appear, or not at all. 

You can see this in action [here](http://35hz.co.uk/topic/423/good-sci-fi-series). Feel free to improve on this if needed. :) 

EDIT: It should probably link to the profile as well. Forgot about that. 
