### PR TITLE
Fix https mixed content on reverse proxies

### DIFF
--- a/less/whiteplum.less
+++ b/less/whiteplum.less
@@ -9,7 +9,7 @@
  * https://github.com/divshot/themestrap
  */
 
-@import url(//fonts.googleapis.com/css?family=Raleway:100,300,700,900,500);
+@import url('https://fonts.googleapis.com/css?family=Raleway:100,300,700,900,500');
 
 .box-shadow(@style) {
   -webkit-box-shadow: @style;


### PR DESCRIPTION
When reverse proxiing your nodebb forum, this theme causes mixed content on your https site...
This PR fixes this issue, non https sites should still work with this!